### PR TITLE
[elasticsearch2] Run as 'elasticsearch' user

### DIFF
--- a/contrib/elasticsearch2/templates/statefulset.yaml
+++ b/contrib/elasticsearch2/templates/statefulset.yaml
@@ -23,6 +23,9 @@ spec:
         release: {{ .Release.Name }}
         component: "elasticsearch"
     spec:
+      securityContext:
+        runAsUser: 101
+        fsGroup: 101
       volumes:
         - name: es-config
           configMap:


### PR DESCRIPTION
## Problem
When `elasticsearch2` comes up, it runs by root as default and attempts to perform a `chown` on its own data directory. This does not work in NFS environments, when `rootsquash` is enabled.

## Approach
Run as `elasticsearch:elasticsearch` instead of root. This makes the `chown` a no-op, since this user should already own this directory and the files within.
