### PR TITLE
Update MLFlow deployment to pick up postgres and minio secrets

### DIFF
--- a/charts/mlflow/templates/_helpers.tpl
+++ b/charts/mlflow/templates/_helpers.tpl
@@ -1,7 +1,11 @@
 {{/*
 Construct a Postgres URI
 */}}
-{{- define "services.postgres.uri"}}postgresql://{{  .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.database }}
+
+{{- define "services.postgres.uri"}}
+{{- if .Values.postgresql.auth.existingSecret }}postgresql://{{  .Values.postgresql.auth.username }}:$(POSTGRES_PASSWORD)@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.database }}
+{{- else }}postgresql://{{  .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.database }}
+{{- end }}
 {{- end }}
 
 

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -34,16 +34,36 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["mlflow"]
-          args: ["server",
-                 "--backend-store-uri", "{{- template "services.postgres.uri" .}}",
-                 "--default-artifact-root", "{{- template "services.minio.uri" . }}"]
           env:
+              {{- if .Values.postgresql.auth.existingSecret }}
+              - name: POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.postgresql.auth.existingSecret }}
+                    key: password
+              {{- end }}
               - name: MLFLOW_S3_ENDPOINT_URL
                 value: "http://{{ .Release.Name }}-minio:{{ .Values.minio.service.ports.api }}"
+            {{- if .Values.minio.auth.existingSecret }}
+              - name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.minio.auth.existingSecret }}
+                    key: root-password
+              - name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.minio.auth.existingSecret }}
+                    key: root-user
+            {{- else }}
               - name: AWS_ACCESS_KEY_ID
                 value: "{{ .Values.minio.auth.rootUser }}"
               - name: AWS_SECRET_ACCESS_KEY
                 value: "{{ .Values.minio.auth.rootPassword }}"
+            {{- end }}
+          args: ["server",
+                 "--backend-store-uri", "{{- template "services.postgres.uri" .}}",
+                 "--default-artifact-root", "{{- template "services.minio.uri" . }}"]
           ports:
             - name: mlflow
               containerPort: 5000


### PR DESCRIPTION
# Problem
We want to set the Postgres and minio sub chart passwords via Kubernetes secrets while still keeping open the option of simple development deployments that put the passwords in a local values.yaml

# Approach
The Postgres and minio sub charts already accept `auth.existingSecret` to pull out these passwords. If those values are set, the MLFlow deployment puts them in environment variables in the container. Some fancy footwork is applied to use the Postgres password in the Postgres uri passed to SQLAlchemy