### PR TITLE
Front MLFlow with OAuth2-Proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 # dependencies (helm dep up)
 charts/*/charts/
+charts/mlflow/deployed-values
+.idea/
+

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -8,12 +8,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.24.0
+appVersion: 2.1.1
 
 # List of people that maintain this helm chart.
 maintainers:

--- a/charts/mlflow/README.MD
+++ b/charts/mlflow/README.MD
@@ -1,0 +1,49 @@
+# MLFlow Helm Chart
+This chart deploys a complete MLFlow instance along with a postgres database
+and minio object store. It can optionally use OAuth2-Proxy to secure access to
+the tracking server for both web browsers and the MLFlow API.
+
+The deployed service will proxy artifact server requests to the object store
+back end so you don't need to distribute AWS_ACCESS_KEYs to users.
+
+## Notes on Authentication
+This chart has been tested out using a [Keycloak](https://www.keycloak.org) as
+the backend identity and access management service. It turns out that teaching 
+OAuth2-proxy to accept JWTs from many common providers is problematic. We 
+settled on Keycloak as the best way to offer the features we want.
+
+It is possible to use Keycloak with a 
+[Device Flow](https://www.rfc-editor.org/rfc/rfc8628) to make it eash to get a 
+valid token from the command line. We developed a 
+[tool](https://pypi.org/project/mlflow-token/) to support this. It assumes that
+the MLflow instance in the user's `MLFLOW_TRACKING_URI` points to a deployment
+made with this chart. It uses an oauth2 endpoint to find the URL of the
+Keycloak realm and starts a device flow against that realm.
+
+### OAuth2-Proxy Secret
+In order for the device flow to work, the OAuth client must be public and not
+require a secret. If you have a deployment that depends on a OAuth secret then
+you can create a kubernetes secret in the namespace. This secret must have the
+following two properties:
+- cookie_secret 
+- client_secret
+
+These values will be read and passed on to the OAuth2-Proxy as environment
+variables.
+
+
+## Configurable Values
+Here are some of the useful settings in `values.yaml` - there are many other
+settings which are typical of most helm charts.
+
+| Value                       | Description                                                        | Default Value |
+|-----------------------------|--------------------------------------------------------------------|---------------|
+| MLFlow.artifacts.bucketName | The bucket where the artifacts will be stored                      |               |
+| services.postgres.enabled   | Deploy a postgres subchart with this chart?                        | true          |
+| services.minio.enabled      | Deploy a minio subchart with this chart?                           | true          |
+| oauth2Proxy.enabled         | Protect the tracking server with an OAuth2 Proxy?                  | true          |
+| oauth2Proxy.secret          | Kubernetes secret holding values to configure the proxy            |               |
+| oauth2Proxy.clientID        | Client ID string for the value in your OAuth2 client.              |               |
+| oauth2Proxy.provider        | A valid  setting for OAuth2-Proxy                                  | keycloak-oidc |
+| oauth2Proxy.emailDomains    | List of domain names for users that will be automatically accepted | *             |
+

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
             {{- end }}
           args: ["server",
                  "--backend-store-uri", "{{- template "services.postgres.uri" . }}",
-                 "--artifacts-destination", "s3://{{ .Values.oauth2Proxy.clientID }}",
+                 "--artifacts-destination", "s3://{{ .Values.MLFlow.artifacts.bucketName }}",
                  "--serve-artifacts",
                  "--host", "0.0.0.0",
                  "--port", "5000"]
@@ -94,8 +94,8 @@ spec:
             - name: https
               containerPort: 8443
               protocol: TCP
-
           env:
+            {{- if .Values.oauth2Proxy.secret }}
             - name: OAUTH2_PROXY_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -106,6 +106,12 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.oauth2Proxy.secret }}
                   key: cookie_secret
+            {{- else }}
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              value: "placeholder to keep OAuth2Proxy happy"
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              value: "placeholder12345"
+            {{- end }}
 
           args: ["--http-address", "0.0.0.0:8443",
                  "--upstream", "http://localhost:5000",

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -71,16 +71,18 @@ spec:
             - name: mlflow
               containerPort: 5000
               protocol: TCP
-#          livenessProbe:
-#            initialDelaySeconds: 45
-#            httpGet:
-#              path: /
-#              port: mlflow
-#          readinessProbe:
-#            initialDelaySeconds: 45
-#            httpGet:
-#              path: /
-#              port: mlflow
+          livenessProbe:
+            initialDelaySeconds: 45
+            periodSeconds: 60
+            httpGet:
+              path: /
+              port: mlflow
+          readinessProbe:
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            httpGet:
+              path: /
+              port: mlflow
 {{- if .Values.oauth2Proxy.enabled }}
         - name: sidecar
           image: "{{- .Values.oauth2Proxy.repository}}:{{- .Values.oauth2Proxy.tag}}"

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
               readOnly: true
 
           ports:
-            - name: https
+            - name: oauth
               containerPort: 8443
               protocol: TCP
           env:

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -62,9 +62,11 @@ spec:
                 value: "{{ .Values.minio.auth.rootPassword }}"
             {{- end }}
           args: ["server",
-                 "--backend-store-uri", "{{- template "services.postgres.uri" .}}",
-                 "--default-artifact-root", "{{- template "services.minio.uri" . }}",
-                 "--host", "0.0.0.0"]
+                 "--backend-store-uri", "{{- template "services.postgres.uri" . }}",
+                 "--artifacts-destination", "s3://{{ .Values.oauth2Proxy.clientID }}",
+                 "--serve-artifacts",
+                 "--host", "0.0.0.0",
+                 "--port", "5000"]
           ports:
             - name: mlflow
               containerPort: 5000
@@ -79,8 +81,37 @@ spec:
 #            httpGet:
 #              path: /
 #              port: mlflow
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+{{- if .Values.oauth2Proxy.enabled }}
+        - name: sidecar
+          image: "{{- .Values.oauth2Proxy.repository}}:{{- .Values.oauth2Proxy.tag}}"
+
+          volumeMounts:
+            - name: oauth2-config
+              mountPath: "/etc/oauth2-proxy"
+              readOnly: true
+
+          ports:
+            - name: https
+              containerPort: 8443
+              protocol: TCP
+
+          env:
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oauth2Proxy.secret }}
+                  key: client_secret
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oauth2Proxy.secret }}
+                  key: cookie_secret
+
+          args: ["--http-address", "0.0.0.0:8443",
+                 "--upstream", "http://localhost:5000",
+                 "--config", "/etc/oauth2-proxy/config.cfg"
+          ]
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -93,3 +124,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: oauth2-config
+          configMap:
+            name: {{ include "mlflow.fullname" . }}-oauth2-config
+{{- end }}

--- a/charts/mlflow/templates/oauth2-config.yaml
+++ b/charts/mlflow/templates/oauth2-config.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.oauth2Proxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mlflow.fullname" . }}-oauth2-config
+  labels:
+    {{- include "mlflow.labels" . | nindent 4 }}
+data:
+  config.cfg: |
+    client_id = "{{ .Values.oauth2Proxy.clientID }}"
+    set_authorization_header = true	
+    skip_jwt_bearer_tokens = true
+    request_logging=true
+    auth_logging=true
+    standard_logging=true
+    provider = "{{- .Values.oauth2Proxy.provider }}"
+    cookie_secure = "false"
+    cookie_refresh = "{{- .Values.oauth2Proxy.cookieRefresh }}"
+    email_domains = "{{- .Values.oauth2Proxy.emailDomains }}"
+    {{- with (first .Values.ingress.hosts) }}
+    redirect_url = "https://{{- .host }}"
+    {{- end }}
+            
+    allowed_roles = 	"{{- .Values.oauth2Proxy.keycloak.allowed_roles }}" 
+    
+    oidc_issuer_url = "{{- .Values.oauth2Proxy.oidc.oidc_issuer_url }}" 
+    oidc_jwks_url = "{{- .Values.oauth2Proxy.oidc.oidc_jwks_url }}"
+    oidc_email_claim = "{{- .Values.oauth2Proxy.oidc.oidc_email_claim }}" 
+    oidc_groups_claim = "{{- .Values.oauth2Proxy.oidc.oidc_groups_claim }}" 
+
+  {{- end }}

--- a/charts/mlflow/templates/service.yaml
+++ b/charts/mlflow/templates/service.yaml
@@ -8,7 +8,11 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
+      {{- if .Values.oauth2Proxy.enabled }}
+      targetPort: https
+      {{- else }}
       targetPort: mlflow
+      {{- end }}
       protocol: TCP
       name: mlflow
   selector:

--- a/charts/mlflow/templates/service.yaml
+++ b/charts/mlflow/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       {{- if .Values.oauth2Proxy.enabled }}
-      targetPort: https
+      targetPort: oauth
       {{- else }}
       targetPort: mlflow
       {{- end }}

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -33,6 +33,41 @@ minio:
   auth:
     rootPassword: leftfoot1
 
+
+oauth2Proxy:
+  enabled: true
+  repository: "bitnami/oauth2-proxy"
+  tag: "7.4.0"
+
+  ## Name of Kubernetes secret holding
+  ##   cookie_secret
+  ##   client_secret
+  secret:
+
+  ## This should match the client ID for your provider
+  clientID:
+  provider: "keycloak-oidc"
+
+  emailDomains: "*"
+  cookieRefresh: "5m"
+  keycloak:
+    # restrict logins to users with this role (may be given multiple times). Only works with the keycloak-oidc provider.
+    allowed_roles:
+
+  oidc:
+    # the OpenID Connect issuer URL, e.g. "https://accounts.google.com"
+    oidc_issuer_url:
+
+    # OIDC JWKS URI for token verification; required if OIDC discovery is disabled
+    oidc_jwks_url:
+
+    # which OIDC claim contains the user's email?
+    oidc_email_claim:
+
+    # which OIDC claim contains the user groups?
+    oidc_groups_claim:
+
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+MLFlow:
+  artifacts:
+    bucketName:
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
# Problem
The MLFlow server has no authentication. Once deployed, any user on the internet can push data or delete runs from the server. We need a way to authenticate users that will work from both the web browser and from command line API calls.

# Approach
Add a sidecar to the MLFlow pod with the OAuth2-Proxy running in it. This proxy will intercept all incoming traffic and route the user to an OAuth flow to log in. It uses browser side cookies when that is available, or accepts correctly signed JWTs for CLI applications.

Added numerous helm chart values to control the settings for this OAuth2-Proxy. During development I found that many supported providers won't work correctly in the command line situation. For now, I've limited settings in `values.yaml` to those that support a known working configuration. We may find new provider configuration and need to add more values once we know what they are.

Previously we were running MLFlow without object store proxy. That meant users needed Minio credentials as well as the MLFlow token. I changed the runtime settings to proxy the object store, so users only need the MLFlow token to publish models.

### Device Flow
For logging to the server from the python SDK, you need a JWT in your bash environment. I figured out a way to obtain this using the Keycloak device flow. I created a [python tool](https://pypi.org/project/mlflow-token/) to hit the MLFlow URL found in the user's MLFLOW_TRACKING_URI, find out the URL for the Keycloak realm backing it, and starting a device flow. 
