### PR TITLE
Updated probe checks due to geoserver upgrade

### DIFF
--- a/charts/geoserver/Chart.yaml
+++ b/charts/geoserver/Chart.yaml
@@ -10,12 +10,12 @@ description: An open source server for sharing geospatial data.
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.23.1
+appVersion: 2.25.2
 
 # List of people that maintain this helm chart.
 maintainers:
@@ -35,6 +35,4 @@ annotations:
     - name: Helm Chart
       url: https://github.com/ncsa/charts
   artifacthub.io/changes: |
-    - Added extra configuration option for setting Java memory heap size.
-    - Fixed bugs in the chart
-    - Port name changed to 'geoserver' from 'http'
+    - Updated probe checks for the deployment due to the geoserver version update

--- a/charts/geoserver/README.md
+++ b/charts/geoserver/README.md
@@ -92,7 +92,7 @@ $ helm install --set persistence.existingClaim=PVC_NAME geoserver
 ## ChangeLog
 
 ### 1.1.1
-- Updated probs check for the deployment due to the geoserver version update
+- Updated probe checks for the deployment due to the geoserver version update
 
 ### 1.1.0
 

--- a/charts/geoserver/README.md
+++ b/charts/geoserver/README.md
@@ -91,6 +91,9 @@ $ helm install --set persistence.existingClaim=PVC_NAME geoserver
 
 ## ChangeLog
 
+### 1.1.1
+- Updated probs check for the deployment due to the geoserver version update
+
 ### 1.1.0
 
 - Added extra configuration option for setting Java memory heap size.

--- a/charts/geoserver/templates/deployment.yaml
+++ b/charts/geoserver/templates/deployment.yaml
@@ -67,18 +67,22 @@ spec:
               mountPath: /opt/geoserver_data
           startupProbe:
             httpGet:
-              path: /geoserver
+              path: /geoserver/
               port: geoserver
             failureThreshold: {{ .Values.startup.failureThreshold }}
             periodSeconds: {{ .Values.startup.periodSeconds }}
           livenessProbe:
             httpGet:
-              path: /geoserver
+              path: /geoserver/
               port: geoserver
+            failureThreshold: {{ .Values.startup.failureThreshold }}
+            periodSeconds: {{ .Values.startup.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /geoserver
+              path: /geoserver/
               port: geoserver
+            failureThreshold: {{ .Values.startup.failureThreshold }}
+            periodSeconds: {{ .Values.startup.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/geoserver/templates/deployment.yaml
+++ b/charts/geoserver/templates/deployment.yaml
@@ -67,17 +67,17 @@ spec:
               mountPath: /opt/geoserver_data
           startupProbe:
             httpGet:
-              path: /geoserver/web
+              path: /geoserver
               port: geoserver
             failureThreshold: {{ .Values.startup.failureThreshold }}
             periodSeconds: {{ .Values.startup.periodSeconds }}
           livenessProbe:
             httpGet:
-              path: /geoserver/web
+              path: /geoserver
               port: geoserver
           readinessProbe:
             httpGet:
-              path: /geoserver/web
+              path: /geoserver
               port: geoserver
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Geoserver needs to be updated to 2.52.2 or higher due to the security issue. To do this, the prob checks in deployment should also be updated.