### PR TITLE
Added an ability of installation of the extensions

### DIFF
--- a/charts/geoserver/Chart.yaml
+++ b/charts/geoserver/Chart.yaml
@@ -10,12 +10,12 @@ description: An open source server for sharing geospatial data.
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.25.2
+appVersion: 2.26.1
 
 # List of people that maintain this helm chart.
 maintainers:
@@ -35,4 +35,5 @@ annotations:
     - name: Helm Chart
       url: https://github.com/ncsa/charts
   artifacthub.io/changes: |
-    - Updated probe checks for the deployment due to the geoserver version update
+    - Added an ability of installation of the extensions
+    - Added variables for CORS configuration

--- a/charts/geoserver/README.md
+++ b/charts/geoserver/README.md
@@ -90,7 +90,7 @@ $ helm install --set persistence.existingClaim=PVC_NAME geoserver
 ```
 
 ## ChangeLog
-### 1.1.2
+### 1.2.0
 - Added an ability of installation of the extensions
 - Added variables for CORS configuration
 

--- a/charts/geoserver/README.md
+++ b/charts/geoserver/README.md
@@ -92,6 +92,7 @@ $ helm install --set persistence.existingClaim=PVC_NAME geoserver
 ## ChangeLog
 ### 1.1.2
 - Added an ability of installation of the extensions
+- Added variables for CORS configuration
 
 ### 1.1.1
 - Updated probe checks for the deployment due to the geoserver version update

--- a/charts/geoserver/README.md
+++ b/charts/geoserver/README.md
@@ -90,6 +90,8 @@ $ helm install --set persistence.existingClaim=PVC_NAME geoserver
 ```
 
 ## ChangeLog
+### 1.1.2
+- Added an ability of installation of the extensions
 
 ### 1.1.1
 - Updated probe checks for the deployment due to the geoserver version update

--- a/charts/geoserver/README.md
+++ b/charts/geoserver/README.md
@@ -90,12 +90,7 @@ $ helm install --set persistence.existingClaim=PVC_NAME geoserver
 ```
 
 ## ChangeLog
-<<<<<<< HEAD
 ### 1.2.0
-=======
-
-### 1.1.2
->>>>>>> bae7dc121e2d48c82256aeec35fcdf21038fd36d
 - Added an ability of installation of the extensions
 - Added variables for CORS configuration
 

--- a/charts/geoserver/templates/deployment.yaml
+++ b/charts/geoserver/templates/deployment.yaml
@@ -37,7 +37,13 @@ spec:
             - name: INSTALL_EXTENSIONS
               value: {{ .Values.extension.install | quote }}
             - name: STABLE_EXTENSIONS
-              value: {{ .Values.extension.stableExtension | quote }}
+              value: {{ .Values.extension.stableExtensions | join `,` | quote }}
+            - name: STABLE_PLUGIN_URL
+              value: {{ .Values.extension.stablePluginUrl | quote }}
+            - name: ADDITIONAL_LIBS_DIR
+              value: {{ .Values.extension.additionalLibsDir | quote }}
+            - name: GEOSERVER_LIB_DIR
+              value: {{ .Values.extension.geoserverLibDir | quote }}
             - name: CORS_ENABLED
               value: {{ .Values.cors.enabled | quote }}
             - name: GEOSERVER_CSRF_WHITELIST

--- a/charts/geoserver/templates/deployment.yaml
+++ b/charts/geoserver/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
             {{- if .Values.cors.enabled }}
             - name: CORS_ALLOWED_ORIGINS
               value: {{ .Values.cors.allowedOrigins | join `,` | quote }}
+            - name: CORS_ALLOWED_METHODS
+              value: {{ .Values.cors.allowedMethods | join `,` | quote }}
+            - name: CORS_ALLOWED_HEADERS
+              value: {{ .Values.cors.allowedHeaders | join `,` | quote }}
             - name: CORS_ALLOW_CREDENTIALS
               value: {{ .Values.cors.allowCredentials | quote }}
             {{- end }}

--- a/charts/geoserver/templates/deployment.yaml
+++ b/charts/geoserver/templates/deployment.yaml
@@ -46,6 +46,12 @@ spec:
               value: {{ .Values.extension.geoserverLibDir | quote }}
             - name: CORS_ENABLED
               value: {{ .Values.cors.enabled | quote }}
+            {{- if .Values.cors.enabled }}
+            - name: CORS_ALLOWED_ORIGINS
+              value: {{ .Values.cors.allowedOrigins | join `,` | quote }}
+            - name: CORS_ALLOW_CREDENTIALS
+              value: {{ .Values.cors.allowCredentials | quote }}
+            {{- end }}
             - name: GEOSERVER_CSRF_WHITELIST
               value: {{ .Values.whitelist | quote }}
             - name: SKIP_DEMO_DATA

--- a/charts/geoserver/values.yaml
+++ b/charts/geoserver/values.yaml
@@ -20,7 +20,10 @@ cors:
 
 extension:
   install: false
-  stableExtension: ""
+  stableExtensions: []
+  stablePluginUrl: ""
+  additionalLibsDir: ""
+  geoserverLibDir: ""
 
 demoData:
   skip: true

--- a/charts/geoserver/values.yaml
+++ b/charts/geoserver/values.yaml
@@ -16,7 +16,9 @@ auth:
   #passwordKey: geoserver-admin-password
 
 cors:
-  enabled: true
+  enabled: false
+  allowedOrigins: []
+  allowCredentials: false
 
 extension:
   install: false

--- a/charts/geoserver/values.yaml
+++ b/charts/geoserver/values.yaml
@@ -17,7 +17,8 @@ auth:
 
 cors:
   enabled: false
-  allowedOrigins: []
+  allowedOrigins:
+    - "*"
   allowedMethods:
     - GET
     - POST

--- a/charts/geoserver/values.yaml
+++ b/charts/geoserver/values.yaml
@@ -18,6 +18,23 @@ auth:
 cors:
   enabled: false
   allowedOrigins: []
+  allowedMethods:
+    - GET
+    - POST
+    - PUT
+    - DELETE
+    - PATCH
+    - HEAD
+    - OPTIONS
+  allowedHeaders:
+    - Origin
+    - Accept
+    - X-Requested-With
+    - Content-Type
+    - Access-Control-Request-Method
+    - Access-Control-Request-Headers
+    - Access-Control-Allow-Origin
+    - Authorization
   allowCredentials: false
 
 extension:


### PR DESCRIPTION
This can be tested by using these variables' values in values.yaml using geoserver version 2.26.1
```
cors:
  enabled: true
  allowedOrigins:
    - http://localhost:3000
  allowCredentials: true

extension:
  install: true
  stableExtensions:
    - grib
    - ogr-wfs
  stablePluginUrl: https://sourceforge.net/projects/geoserver/files/GeoServer/2.26.1/extensions/
  additionalLibsDir: /opt/
  geoserverLibDir: /usr/local/tomcat/webapps/geoserver/WEB-INF/lib
```